### PR TITLE
Changed settings to make xdebug work.

### DIFF
--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,16 +1,5 @@
-; NOTE: The actual debug.so extention is NOT SET HERE but rather (/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini)
+zend_extension=xdebug.so
 
-xdebug.remote_autostart=0
-xdebug.remote_enable=0
-xdebug.remote_connect_back=0
-xdebug.cli_color=0
-xdebug.profiler_enable=0
-xdebug.remote_handler=dbgp
-xdebug.remote_mode=req
-
-xdebug.remote_port=9000
-xdebug.remote_host=dockerhost
-xdebug.idekey=PHPSTORM
-
-xdebug.show_exception_trace = 0
-xdebug.max_nesting_level = 256
+xdebug.remote_enable=1
+xdebug.remote_connect_back=1
+xdebug.remote_port=9001


### PR DESCRIPTION
These are the changes which needed to be made to get xdebug working.

Note that the xdebug port is set to 9001 to avoid clashing - this is not the default xdebug port and would need to be set on the xdebug client.

(Note also that to create the PHP7.2 image we had to comment out
--enable-gd-native-ttf
in the Docker file.  This may be something to do with our setup - or it may be to do with this being PHP 7.2).